### PR TITLE
🐛 Fix deployment update conflicts

### DIFF
--- a/deploy/helm/templates/clusterrole.yaml
+++ b/deploy/helm/templates/clusterrole.yaml
@@ -36,6 +36,7 @@ rules:
       - get
       - update
       - list
+      - patch
   {{- else }}
   - apiGroups:
       - "apps"
@@ -45,5 +46,6 @@ rules:
       - get
       - update
       - list
+      - patch
   {{- end }}
 {{- end }}

--- a/deploy/helm/templates/role.yaml
+++ b/deploy/helm/templates/role.yaml
@@ -38,6 +38,7 @@ rules:
       - get
       - update
       - list
+      - patch
   {{- else }}
   - apiGroups:
       - "apps"
@@ -47,5 +48,6 @@ rules:
       - get
       - update
       - list
+      - patch
   {{- end }}
 {{- end }}

--- a/deploy/kubectl/proxless.yaml
+++ b/deploy/kubectl/proxless.yaml
@@ -104,3 +104,4 @@ rules:
       - get
       - update
       - list
+      - patch

--- a/deploy/oc/proxless.yaml
+++ b/deploy/oc/proxless.yaml
@@ -106,3 +106,4 @@ rules:
       - get
       - update
       - list
+      - patch

--- a/example/kubectl/example.yaml
+++ b/example/kubectl/example.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello
+  labels:
+    app: hello
 spec:
   selector:
     matchLabels:
@@ -42,6 +44,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
+  labels:
+    app: frontend
 spec:
   selector:
     matchLabels:

--- a/example/oc/example.yaml
+++ b/example/oc/example.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: DeploymentConfig
 metadata:
   name: hello
+  labels:
+    app: hello
 spec:
   selector:
     app: hello
@@ -41,6 +43,8 @@ apiVersion: v1
 kind: DeploymentConfig
 metadata:
   name: frontend
+  labels:
+    app: frontend
 spec:
   selector:
     app: hello

--- a/internal/cluster/kube/deployment_test.go
+++ b/internal/cluster/kube/deployment_test.go
@@ -51,7 +51,7 @@ func Test_labelDeployment(t *testing.T) {
 	deploy, err = labelDeployment(clientSet, dummyNonProxlessName, dummyNamespaceName)
 	assert.NoError(t, err)
 
-	wantLabels := map[string]string{utils2.LabelDeploymentProxless: "true"}
+	wantLabels := map[string]string{"app": dummyNonProxlessName, utils2.LabelDeploymentProxless: "true"}
 	if !utils.CompareMap(deploy.Labels, wantLabels) {
 		t.Errorf("labelDeployment(); labels = %s, wantLabels = %s", deploy.Labels, wantLabels)
 	}

--- a/internal/cluster/kube/helper_test.go
+++ b/internal/cluster/kube/helper_test.go
@@ -57,6 +57,7 @@ func helper_createRandomDeployment(t *testing.T, clientSet kubernetes.Interface)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dummyNonProxlessName,
 			Namespace: dummyNamespaceName,
+			Labels:    map[string]string{"app": dummyNonProxlessName},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: pointer.Int32Ptr(1),

--- a/internal/cluster/kube/kube_test.go
+++ b/internal/cluster/kube/kube_test.go
@@ -100,7 +100,7 @@ func TestClusterClient_RunServicesEngine(t *testing.T) {
 	helper_createRandomDeployment(t, clientSet)
 	time.Sleep(time.Duration(servicesInformerResyncInterval) * time.Second)
 	randomDeploy, _ := getDeployment(clientSet, dummyNonProxlessName, dummyNamespaceName)
-	labelsWant := map[string]string{clusterutils.LabelDeploymentProxless: "true"}
+	labelsWant := map[string]string{"app": dummyNonProxlessName, clusterutils.LabelDeploymentProxless: "true"}
 	if !utils.CompareMap(randomDeploy.Labels, labelsWant) {
 		t.Errorf("RunServicesEngine(); deployment must have the label; labels = %s; labelsWant = %s",
 			randomDeploy.Labels, labelsWant)
@@ -111,7 +111,7 @@ func TestClusterClient_RunServicesEngine(t *testing.T) {
 	helper_updateService(t, clientSet, service)
 	time.Sleep(1 * time.Second)
 	randomDeploy, _ = getDeployment(clientSet, dummyNonProxlessName, dummyNamespaceName)
-	if len(randomDeploy.Labels) > 0 {
+	if _, ok := randomDeploy.Labels[clusterutils.LabelDeploymentProxless]; ok {
 		t.Errorf("RunServicesEngine(); labels must be removed; labels = %s", randomDeploy.Labels)
 	}
 


### PR DESCRIPTION
- proxless will now patch the deployment in order to avoid the deployment
update conflict happening when the deployment is being update while another
update is happening (not related to proxless)