### PR TITLE
🐛 Fix route id

### DIFF
--- a/internal/cluster/kube/kube_test.go
+++ b/internal/cluster/kube/kube_test.go
@@ -87,7 +87,8 @@ func TestClusterClient_RunServicesEngine(t *testing.T) {
 	// add proxless compatible services into memory
 	service := helper_createProxlessCompatibleService(t, clientSet)
 	time.Sleep(1 * time.Second)
-	if _, ok := memory.m[string(service.UID)]; !ok {
+	id := clusterutils.GenRouteId(service.Name, service.Namespace)
+	if _, ok := memory.m[id]; !ok {
 		t.Errorf("RunServicesEngine(); service not added in memory")
 	}
 	_, err :=

--- a/internal/cluster/kube/service.go
+++ b/internal/cluster/kube/service.go
@@ -95,7 +95,8 @@ func addServiceToMemory(
 
 		port := getPortFromServicePorts(svc.Spec.Ports)
 
-		err = upsertMemory(string(svc.UID), svc.Name, port, deployName, svc.Namespace, domains, ttlSeconds, readinessTimeoutSeconds)
+		id := clusterutils.GenRouteId(svc.Name, svc.Namespace)
+		err = upsertMemory(id, svc.Name, port, deployName, svc.Namespace, domains, ttlSeconds, readinessTimeoutSeconds)
 
 		if err == nil {
 			logger.Debugf("Service %s.%s added into memory", svc.Name, svc.Namespace)
@@ -128,7 +129,8 @@ func removeServiceFromMemory(
 
 		_ = deleteProxlessService(clientset, svc.Name, svc.Namespace)
 
-		err := deleteRouteFromMemory(string(svc.UID))
+		id := clusterutils.GenRouteId(svc.Name, svc.Namespace)
+		err := deleteRouteFromMemory(id)
 
 		if err == nil {
 			logger.Debugf("Service %s.%s removed from memory", svc.Name, svc.Namespace)

--- a/internal/cluster/utils/utils.go
+++ b/internal/cluster/utils/utils.go
@@ -11,6 +11,10 @@ func GenServiceToAppName(svcName string) string {
 	return fmt.Sprintf("%s-proxless", svcName)
 }
 
+func GenRouteId(svc, ns string) string {
+	return fmt.Sprintf("%s.%s", svc, ns)
+}
+
 func GenDomains(domains, name, namespace string, namespaceScoped bool) []string {
 	svcName := GenServiceToAppName(name)
 	var domainsArray []string


### PR DESCRIPTION
- Route id used to be the UID of the service. But if proxless, for any
reason, miss an event and the service UID changes (delete/recreate), the
route will never be updated and it will cuz proxless failure. The new id
is `{serviceName}.{serviceNamespace}`.